### PR TITLE
fix(.readthedocs.yaml): changed Python version for readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: "2"
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
 
 python:
   install:


### PR DESCRIPTION
Changed the Python version for the readthedocs build from 3.10 to 3.11 because FhY requires at least 3.11.