### PR TITLE
Visit testing

### DIFF
--- a/src/fhy/lang/ast/serialization/to_json.py
+++ b/src/fhy/lang/ast/serialization/to_json.py
@@ -174,6 +174,13 @@ class ASTtoJSON(visitor.BasePass):
 
         return obj
 
+    def visit_Import(self, node: ast.Import) -> AlmostJson:
+        identifier: AlmostJson = self.visit_Identifier(node.name)
+        return AlmostJson(
+            cls_name=visitor.get_cls_name(node),
+            attributes=dict(span=self.visit_Span(node.span), name=identifier),
+        )
+
     def visit_Argument(self, node: ast.Argument) -> AlmostJson:
         qtype: AlmostJson = self.visit_QualifiedType(node.qualified_type)
         name: AlmostJson | None = (
@@ -560,6 +567,16 @@ class JSONtoAST(visitor.BasePass):
         return ast.Procedure(
             span=span, name=name, templates=templates, args=args, body=body
         )
+
+    def visit_Import(self, node: AlmostJson | None) -> ast.Import:
+        if node is None:
+            raise ValueError("Invalid Import statement")
+
+        values: dict = node.attributes
+        span: Span | None = self.visit_Span(values.get("span"))
+        name: ir.Identifier = self.visit_Identifier(values.get("name"))
+
+        return ast.Import(span=span, name=name)
 
     def visit_Argument(self, node: AlmostJson | None) -> ast.Argument:
         if node is None:

--- a/src/fhy/lang/ast/visitor.py
+++ b/src/fhy/lang/ast/visitor.py
@@ -49,6 +49,7 @@ from fhy.ir.type import IndexType as IRIndexType
 from fhy.ir.type import NumericalType as IRNumericalType
 from fhy.ir.type import PrimitiveDataType as IRPrimitiveDataType
 from fhy.ir.type import TemplateDataType as IRTemplateDataType
+from fhy.ir.type import TupleType as IRTupleType
 from fhy.ir.type import Type as IRType
 from fhy.ir.type import TypeQualifier as IRTypeQualifier
 from fhy.lang.ast.alias import ASTObject
@@ -377,6 +378,15 @@ class Visitor(BasePass):
         self.visit(index_type.upper_bound)
         if index_type.stride is not None:
             self.visit(index_type.stride)
+
+    def visit_TupleType(self, tuple_type: IRTupleType) -> None:
+        """Visit a tuple type.
+
+        Args:
+            tuple_type (ir.TupleType): Tuple type to visit.
+
+        """
+        self.visit(tuple_type.types)
 
     def visit_PrimitiveDataType(self, node: IRPrimitiveDataType) -> None:
         """Visit a primitive data type.
@@ -829,6 +839,8 @@ class Transformer(BasePass):
             return self.visit_NumericalType(node)
         elif isinstance(node, IRIndexType):
             return self.visit_IndexType(node)
+        elif isinstance(node, IRTupleType):
+            return self.visit_TupleType(node)
         else:
             raise NotImplementedError(f'Node "{type(node)}" is not supported.')
 
@@ -864,6 +876,17 @@ class Transformer(BasePass):
             upper_bound=new_upper_bound,
             stride=new_stride,
         )
+
+    def visit_TupleType(self, tuple_type: IRTupleType) -> IRTupleType:
+        """Transform a tuple type node.
+
+        Args:
+            tuple_type (ir.TupleType): TupleType node to transform.
+
+        """
+        new_types = self.visit_Types(tuple_type.types)
+
+        return IRTupleType(types=new_types)
 
     def visit_PrimitiveDataType(self, node: IRPrimitiveDataType) -> IRPrimitiveDataType:
         """Transform a primitive type node.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,6 +34,7 @@ from fhy.lang.ast import (
     ForAllStatement,
     FunctionExpression,
     IdentifierExpression,
+    Import,
     IntLiteral,
     Module,
     Operation,
@@ -574,6 +575,18 @@ def return_state(span_node, unary) -> tuple[dict, ReturnStatement]:
     )
 
     return obj, statement
+
+
+@add_fixture_node
+@pytest.fixture
+def import_node(span_node, construct_id) -> tuple[dict, Import]:
+    text: str = "import x.y;"
+    span_obj, span_cls = span_node
+    id_obj, id_cls = construct_id("x.y")
+    obj = dict(cls_name="Import", attributes=dict(span=span_obj, name=id_obj))
+    import_statement = Import(span=span_cls, name=id_cls)
+
+    return obj, import_statement
 
 
 # FUNCTIONS

--- a/tests/unit/test_visitor.py
+++ b/tests/unit/test_visitor.py
@@ -89,14 +89,28 @@ def test_visitor_transform_tuple_access_expression():
     assert isinstance(result, TupleAccessExpression)
     assert result.element_index.value == 0
 
+    assert id(tuple_access_expression_node) != id(result), "Expected Shallow copy."
+    assert id(tuple_access_expression_node.tuple_expression) != id(
+        result.tuple_expression
+    ), "Expected Shallow copy."
+    assert id(tuple_access_expression_node.element_index) != id(
+        result.element_index
+    ), "Expected Shallow copy."
+
 
 def test_visitor_transform_complex_literal():
     """Verifys the Transformer class transforms a ComplexLiteral node correctly."""
     transformer = visitor.Transformer()
-    complex_literal_node = ComplexLiteral(span=None, value=complex(1, 1))
+    value = complex(1025, 4097)
+    complex_literal_node = ComplexLiteral(span=None, value=value)
     result = transformer.visit_ComplexLiteral(complex_literal_node)
     assert isinstance(result, ComplexLiteral)
-    assert result.value == complex(1, 1)
+    assert result.value == value
+
+    assert id(complex_literal_node) != id(result), "Expected Shallow copy."
+
+    # NOTE: The value will be identical, since this is a shallow copy
+    assert id(complex_literal_node.value) == id(result.value), "Expected Shallow copy."
 
 
 def test_visitor_transform_type():

--- a/tests/unit/test_visitor.py
+++ b/tests/unit/test_visitor.py
@@ -1,21 +1,235 @@
+from collections.abc import Callable
+from typing import TypeVar
+from unittest.mock import MagicMock, patch
+
 import pytest
-from fhy.lang.ast import Module, visitor
+from fhy.ir.identifier import Identifier as IRIdentifier
+from fhy.ir.type import CoreDataType, PrimitiveDataType
+from fhy.ir.type import NumericalType as IRNumericalType
+from fhy.lang.ast import (
+    ComplexLiteral,
+    ExpressionStatement,
+    IntLiteral,
+    Module,
+    Operation,
+    Procedure,
+    TupleAccessExpression,
+    TupleExpression,
+    visitor,
+)
+from fhy.lang.ast.alias import ASTObject
+from fhy.lang.ast.visitor import BasePass, Visitor
+
+BP = TypeVar("BP", bound=BasePass)
 
 
 @pytest.fixture(scope="module")
-def base_visitor():
-    class Base(visitor.BasePass):
-        def visit_Module(self, node: Module) -> bool:
-            return True
+def module_node():
+    operation_node = Operation(
+        span=None,
+        name=IRIdentifier("operation_name"),
+        args=[],
+        return_type=None,
+        body=[],
+    )
+    procedure_node = Procedure(
+        span=None, name=IRIdentifier("procedure_name"), args=[], body=[]
+    )
+    return Module(
+        span=None,
+        name=IRIdentifier("module_name"),
+        statements=[operation_node, procedure_node],
+    )
 
-    return Base
+
+def test_visitor_initialization():
+    """Check if the Visitor class can be instantiated."""
+    visitor = Visitor()
+    assert visitor is not None, "Visitor instance should not be None"
 
 
-def test_visitor_base(base_visitor):
-    """Tests the behavior of a primitive Subclass of the visitor pattern BasePass"""
-    instance = base_visitor()
-    node = Module(span=None)
+def test_visitor_visit_module(module_node):
+    """Verify the Visitor class processes a Module node correctly."""
+    visitor = Visitor()
+    visitor.visit_Module = MagicMock(name="visit_Module")
+    visitor.visit(module_node)
+    visitor.visit_Module.assert_called_once_with(module_node)
 
-    assert instance.visit(node), "Did not Visit Module Node."
-    assert instance(node), "Did not Visit Module Node"
-    assert instance.visit_Module(node), "Did Not Visit Module Node"
+
+def test_visitor_unimplemented_visit_method():
+    """Test behavior when a visit method for a specific node type is not implemented."""
+    visitor = Visitor()
+    unknown_node = MagicMock(name="Unknown")
+    unknown_node.span = None
+
+    with pytest.raises(NotImplementedError):
+        visitor.visit(unknown_node)
+
+
+def test_visitor_default_method():
+    """Test the default method for unsupported nodes."""
+    visitor = Visitor()
+    unsupported_node = MagicMock(name="UnsupportedNode")
+    with pytest.raises(NotImplementedError):
+        visitor.default(unsupported_node)
+
+
+def test_visitor_transform_expression_statement():
+    """Verify the Transformer class transforms an ExpressionStatement node correctly."""
+    transformer = visitor.Transformer()
+    expression_statement_node = ExpressionStatement(
+        span=None, left=None, right=IntLiteral(span=None, value=1)
+    )
+    result = transformer.visit_ExpressionStatement(expression_statement_node)
+    assert isinstance(result, ExpressionStatement)
+    assert result.right.value == 1
+
+
+def test_visitor_transform_tuple_expression():
+    """Verifys the Transformer class transforms a TupleExpression node correctly."""
+    transformer = visitor.Transformer()
+    tuple_expression_node = TupleExpression(
+        span=None, expressions=[IntLiteral(span=None, value=1)]
+    )
+    result = transformer.visit_TupleExpression(tuple_expression_node)
+    assert isinstance(result, TupleExpression)
+    assert result.expressions[0].value == 1
+
+
+def test_visitor_transform_tuple_access_expression():
+    """Verifys Transformer class transforms a TupleAccessExpression node correctly."""
+    transformer = visitor.Transformer()
+    tuple_access_expression_node = TupleAccessExpression(
+        span=None,
+        tuple_expression=IntLiteral(span=None, value=1),
+        element_index=IntLiteral(span=None, value=0),
+    )
+    result = transformer.visit_TupleAccessExpression(tuple_access_expression_node)
+    assert isinstance(result, TupleAccessExpression)
+    assert result.element_index.value == 0
+
+
+def test_visitor_transform_complex_literal():
+    """Verifys the Transformer class transforms a ComplexLiteral node correctly."""
+    transformer = visitor.Transformer()
+    complex_literal_node = ComplexLiteral(span=None, value=complex(1, 1))
+    result = transformer.visit_ComplexLiteral(complex_literal_node)
+    assert isinstance(result, ComplexLiteral)
+    assert result.value == complex(1, 1)
+
+
+def test_visitor_transform_type():
+    """Verifys the Transformer class transforms a Type node correctly."""
+    transformer = visitor.Transformer()
+    primitive_data_type = CoreDataType.FLOAT32
+    numerical_type_node = IRNumericalType(
+        data_type=PrimitiveDataType(core_data_type=primitive_data_type),
+        shape=[],
+    )
+    result = transformer.visit_Type(numerical_type_node)
+    assert isinstance(result, IRNumericalType)
+
+
+def mock_transform(x):
+    return x
+
+
+def default_assert(
+    instance: BP, method: MagicMock, node: ASTObject, transform=mock_transform
+):
+    # We check `__call__`, generic `visit`, and mocked `method` directly.
+    for call in (instance, instance.visit, method):
+        call(node)
+        method.assert_called_once_with(transform(node))
+        method.reset_mock()
+
+
+def visit_generic(
+    name: str, obj: BP, _test=default_assert, transform=mock_transform
+) -> Callable[[ASTObject], BP]:
+    """Dynamic Construction of a mock patched base pass."""
+
+    @patch.object(obj, name)
+    def inner(node, mock_method) -> BP:
+        instance = obj()
+        method = getattr(instance, name)
+
+        assert isinstance(method, MagicMock), f"Method {name} is not properly mocked."
+        assert isinstance(
+            mock_method, MagicMock
+        ), f"Method {name} is not properly mocked."
+        assert method == mock_method, "Should be same mock method..."
+        _test(instance, method, node, transform)
+
+        return instance
+
+    return inner
+
+
+fixtures = [
+    # Types
+    ("index_type", "visit_IndexType"),
+    ("tuple_type", "visit_TupleType"),
+    ("qualified", "visit_QualifiedType"),
+    ("arg1", "visit_Argument"),
+    # Expressions
+    ("unary", "visit_UnaryExpression"),
+    ("binary", "visit_BinaryExpression"),
+    ("ternary", "visit_TernaryExpression"),
+    ("tuple_access", "visit_TupleAccessExpression"),
+    ("function_call", "visit_FunctionExpression"),
+    ("array_access", "visit_ArrayAccessExpression"),
+    ("tuple_express", "visit_TupleExpression"),
+    ("id_express", "visit_IdentifierExpression"),
+    # Statements
+    ("declaration", "visit_DeclarationStatement"),
+    ("express_state", "visit_ExpressionStatement"),
+    ("iteration_state", "visit_ForAllStatement"),
+    ("select_state", "visit_SelectionStatement"),
+    ("return_state", "visit_ReturnStatement"),
+    ("import_node", "visit_Import"),
+    # Functions
+    ("operation", "visit_Operation"),
+    ("procedure", "visit_Procedure"),
+    ("module", "visit_Module"),
+]
+
+
+@pytest.mark.parametrize(["cls_name"], [(Visitor,), (visitor.Transformer,)])
+@pytest.mark.parametrize(["fixture_name", "method_name"], fixtures)
+def test_visit_ast_node_fixtures(
+    fixture_name: str, method_name: str, cls_name: BP, request: pytest.FixtureRequest
+):
+    """Test core functionality of the visitor base pass pattern: dispatching.
+
+    Use statically constructed ast fixtures coupled to the method name we expect
+    to be called for a given node. This doesn't validate downstream behavior of
+    the given visit method in itself. That is, we only confirm we correctly visit the
+    root node.
+
+    """
+    _obj, node = request.getfixturevalue(fixture_name)
+    mocker: Callable[[ASTObject], BP] = visit_generic(
+        method_name, cls_name, default_assert
+    )
+    instance: BP = mocker(node)
+
+
+def test_module_node(module):
+    """Test correct nodes are visited from a Module node."""
+    obj, node = module
+
+    def mock_assert(instance: BP, method: MagicMock, _node: ASTObject, t):
+        instance.visit(_node)
+        method.assert_called_once_with(t(_node))
+
+    for s, transform in (
+        ("visit_sequence", lambda x: x.statements),
+        ("visit_Operation", lambda x: x.statements[0]),
+        ("visit_Procedure", lambda x: x.statements[1]),
+        # ("visit_Span", lambda x: x.span),  # visitor pattern is not visiting span
+    ):
+        mocker: Callable[[ASTObject], BP] = visit_generic(
+            s, Visitor, mock_assert, transform
+        )
+        mocker(node)


### PR DESCRIPTION
1. Implement patch base magic mocking of methods to test behavior of visitor pattern
2. Support import node in json serialization (added new fixture in conftest)
3. Include tuple-type node in visitor / transformer patterns